### PR TITLE
Normalize scoped package names on Windows

### DIFF
--- a/src/-private/plugin-names.ts
+++ b/src/-private/plugin-names.ts
@@ -78,7 +78,10 @@ function findPackageName(modulePath: string): string {
 
   let packageNameStartIndex = modulePath.lastIndexOf(match[0]) + match[0].length;
   let packageNameWithEntryPoint = modulePath.substring(packageNameStartIndex);
-  return packageNameRegex.exec(packageNameWithEntryPoint)![1];
+  let packageName = packageNameRegex.exec(packageNameWithEntryPoint)![1];
+
+  // Normalize from '\' to `/` for scoped package names on Windows
+  return packageName.replace('\\', '/');
 }
 
 function isPath(name: string): boolean {

--- a/tests/-private/plugin-names-test.ts
+++ b/tests/-private/plugin-names-test.ts
@@ -59,6 +59,14 @@ describe('Utilities | plugin-names', () => {
       expect(resolvePluginName('/full/path/to/node_modules/@scope/resolved-plugin-name/index.js')).to.equal(
         '@scope/resolved-plugin-name'
       );
+
+      expect(resolvePluginName('C:\\full\\path\\to\\node_modules\\resolved-plugin-name\\index.js')).to.equal(
+        'resolved-plugin-name'
+      );
+
+      expect(resolvePluginName('C:\\full\\path\\to\\node_modules\\@scope\\resolved-plugin-name\\index.js')).to.equal(
+        '@scope/resolved-plugin-name'
+      );
     });
   });
 });

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -9,11 +9,14 @@ describe('Public Helpers', () => {
     let normalizedNamePlugin: BabelPluginConfig = ['babel-plugin-long-name', {}, 'id'];
     let fullPathPlugin: BabelPluginConfig = ['/path/to/node_modules/babel-plugin-full-path/index.js'];
     let scopedPathPlugin: BabelPluginConfig = ['/path/to/node_modules/@scope/babel-plugin-scoped-path/lib/plugin.js'];
+    let scopedWindowsPathPlugin: BabelPluginConfig = [
+      'C:\\path\\to\\node_modules\\@scope\\babel-plugin-scoped-windows-path\\lib\\plugin.js'
+    ];
 
     let target = {
       options: {
         babel: {
-          plugins: [shortNamePlugin, normalizedNamePlugin, fullPathPlugin, scopedPathPlugin]
+          plugins: [shortNamePlugin, normalizedNamePlugin, fullPathPlugin, scopedPathPlugin, scopedWindowsPathPlugin]
         }
       }
     };
@@ -32,6 +35,9 @@ describe('Public Helpers', () => {
 
       expect(hasPlugin(target, '@scope/scoped-path')).to.be.true;
       expect(hasPlugin(target, '@scope/babel-plugin-scoped-path')).to.be.true;
+
+      expect(hasPlugin(target, '@scope/scoped-windows-path')).to.be.true;
+      expect(hasPlugin(target, '@scope/babel-plugin-scoped-path')).to.be.true;
     });
   });
 
@@ -40,11 +46,14 @@ describe('Public Helpers', () => {
     let normalizedNamePlugin: BabelPluginConfig = ['babel-plugin-long-name', {}, 'id'];
     let fullPathPlugin: BabelPluginConfig = ['/path/to/node_modules/babel-plugin-full-path/index.js'];
     let scopedPathPlugin: BabelPluginConfig = ['/path/to/node_modules/@scope/babel-plugin-scoped-path/lib/plugin.js'];
+    let scopedWindowsPathPlugin: BabelPluginConfig = [
+      'C:\\path\\to\\node_modules\\@scope\\babel-plugin-scoped-windows-path\\lib\\plugin.js'
+    ];
 
     let target = {
       options: {
         babel: {
-          plugins: [shortNamePlugin, normalizedNamePlugin, fullPathPlugin, scopedPathPlugin]
+          plugins: [shortNamePlugin, normalizedNamePlugin, fullPathPlugin, scopedPathPlugin, scopedWindowsPathPlugin]
         }
       }
     };
@@ -63,6 +72,9 @@ describe('Public Helpers', () => {
 
       expect(findPlugin(target, '@scope/scoped-path')).to.equal(scopedPathPlugin);
       expect(findPlugin(target, '@scope/babel-plugin-scoped-path')).to.equal(scopedPathPlugin);
+
+      expect(findPlugin(target, '@scope/scoped-windows-path')).to.equal(scopedWindowsPathPlugin);
+      expect(findPlugin(target, '@scope/babel-plugin-scoped-windows-path')).to.equal(scopedWindowsPathPlugin);
     });
   });
 


### PR DESCRIPTION
We were mostly handling Windows paths correctly, but weren't normalizing `@scope\package` to `@scope/package`, so `hasPlugin` lookups could fail.

@bouke I believe this is the underlying issue you're running into from what you mentioned in Discord.