### PR TITLE
Always resolve path after `module:` prefix untouched

### DIFF
--- a/src/-private/plugin-names.ts
+++ b/src/-private/plugin-names.ts
@@ -5,6 +5,9 @@ export function resolvePluginName(pluginConfig: BabelPluginConfig): string | voi
   let plugin = Array.isArray(pluginConfig) ? pluginConfig[0] : pluginConfig;
 
   if (typeof plugin === 'string') {
+    if (plugin.startsWith('module:')) {
+      return normalizePluginName(plugin);
+    }
     if (isPath(plugin)) {
       return findPackageName(plugin);
     } else {

--- a/tests/-private/plugin-configuration-test.ts
+++ b/tests/-private/plugin-configuration-test.ts
@@ -4,7 +4,12 @@ import { findPluginIndex } from '../../src/-private/plugin-configuration';
 
 describe('Utilities | plugin-configuration', () => {
   describe('findPluginIndex', () => {
-    let plugins = ['short-name', 'babel-plugin-long-name', '/path/to/node_modules/babel-plugin-full-path/index.js'];
+    let plugins = [
+      'short-name',
+      'babel-plugin-long-name',
+      '/path/to/node_modules/babel-plugin-full-path/index.js',
+      'module:/path/to/node_modules/babel-plugin-full-path/index.js'
+    ];
 
     it('correctly returns -1', () => {
       expect(findPluginIndex([], 'foo-bar')).to.equal(-1);
@@ -20,6 +25,10 @@ describe('Utilities | plugin-configuration', () => {
       expect(findPluginIndex(plugins, 'babel-plugin-short-name')).to.equal(0);
       expect(findPluginIndex(plugins, 'babel-plugin-long-name')).to.equal(1);
       expect(findPluginIndex(plugins, 'babel-plugin-full-path')).to.equal(2);
+    });
+
+    it('locates plugins by full path when requeted with `module:` prefix', () => {
+      expect(findPluginIndex(plugins, 'module:/path/to/node_modules/babel-plugin-full-path/index.js')).to.equal(3);
     });
   });
 });

--- a/tests/-private/plugin-names-test.ts
+++ b/tests/-private/plugin-names-test.ts
@@ -68,5 +68,11 @@ describe('Utilities | plugin-names', () => {
         '@scope/resolved-plugin-name'
       );
     });
+
+    it('resolves full path after `module:` prefix untouched', () => {
+      expect(resolvePluginName('module:/full/path/to/node_modules/resolved-plugin-name/index.js')).to.equal(
+        '/full/path/to/node_modules/resolved-plugin-name/index.js'
+      );
+    });
   });
 });

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -12,8 +12,16 @@ describe('Public Helpers', () => {
     let scopedWindowsPathPlugin: BabelPluginConfig = [
       'C:\\path\\to\\node_modules\\@scope\\babel-plugin-scoped-windows-path\\lib\\plugin.js'
     ];
+    let modulePlugin: BabelPluginConfig = ['module:/path/to/node_modules/some-package/lib/babel-plugin-name.js'];
 
-    let config = [shortNamePlugin, normalizedNamePlugin, fullPathPlugin, scopedPathPlugin, scopedWindowsPathPlugin];
+    let config = [
+      shortNamePlugin,
+      normalizedNamePlugin,
+      fullPathPlugin,
+      scopedPathPlugin,
+      scopedWindowsPathPlugin,
+      modulePlugin
+    ];
 
     it('locates plugins by short and normalized names', () => {
       expect(hasPlugin(config, 'nonexistent')).to.be.false;
@@ -33,6 +41,10 @@ describe('Public Helpers', () => {
       expect(hasPlugin(config, '@scope/scoped-windows-path')).to.be.true;
       expect(hasPlugin(config, '@scope/babel-plugin-scoped-path')).to.be.true;
     });
+
+    it('locates plugins by module path', () => {
+      expect(hasPlugin(config, 'module:/path/to/node_modules/some-package/lib/babel-plugin-name.js')).to.be.true;
+    });
   });
 
   describe('findPlugin', () => {
@@ -43,8 +55,16 @@ describe('Public Helpers', () => {
     let scopedWindowsPathPlugin: BabelPluginConfig = [
       'C:\\path\\to\\node_modules\\@scope\\babel-plugin-scoped-windows-path\\lib\\plugin.js'
     ];
+    let modulePlugin: BabelPluginConfig = ['module:/path/to/node_modules/some-package/lib/babel-plugin-name.js'];
 
-    let config = [shortNamePlugin, normalizedNamePlugin, fullPathPlugin, scopedPathPlugin, scopedWindowsPathPlugin];
+    let config = [
+      shortNamePlugin,
+      normalizedNamePlugin,
+      fullPathPlugin,
+      scopedPathPlugin,
+      scopedWindowsPathPlugin,
+      modulePlugin
+    ];
 
     it('locates plugins by short and normalized names', () => {
       expect(findPlugin(config, 'nonexistent')).to.be.undefined;
@@ -63,6 +83,12 @@ describe('Public Helpers', () => {
 
       expect(findPlugin(config, '@scope/scoped-windows-path')).to.equal(scopedWindowsPathPlugin);
       expect(findPlugin(config, '@scope/babel-plugin-scoped-windows-path')).to.equal(scopedWindowsPathPlugin);
+    });
+
+    it('locates plugins by module path', () => {
+      expect(findPlugin(config, 'module:/path/to/node_modules/some-package/lib/babel-plugin-name.js')).to.equal(
+        modulePlugin
+      );
     });
   });
 


### PR DESCRIPTION
When a plugin is listed in the config with the `module:` prefix, it should resolve to the path after `module:` untouched rather than the package name.