### PR TITLE
Support full path to plugins in non-babel-plugin packages

### DIFF
--- a/src/-private/plugin-names.ts
+++ b/src/-private/plugin-names.ts
@@ -6,7 +6,17 @@ export function resolvePluginName(pluginConfig: BabelPluginConfig): string | voi
 
   if (typeof plugin === 'string') {
     if (isPath(plugin)) {
-      return findPackageName(plugin);
+      let packageName = findPackageName(plugin);
+      let { scope, name } = extractScope(packageName);
+      if (
+        (!scope && name.startsWith('babel-plugin-')) ||
+        (scope === '@babel' && name.startsWith('plugin-')) ||
+        (scope && /\bbabel-plugin\b/.test(name))
+      ) {
+        return packageName;
+      } else {
+        return plugin;
+      }
     } else {
       return normalizePluginName(plugin);
     }

--- a/tests/-private/plugin-configuration-test.ts
+++ b/tests/-private/plugin-configuration-test.ts
@@ -4,7 +4,13 @@ import { findPluginIndex } from '../../src/-private/plugin-configuration';
 
 describe('Utilities | plugin-configuration', () => {
   describe('findPluginIndex', () => {
-    let plugins = ['short-name', 'babel-plugin-long-name', '/path/to/node_modules/babel-plugin-full-path/index.js'];
+    let plugins = [
+      'short-name',
+      'babel-plugin-long-name',
+      '/path/to/node_modules/babel-plugin-full-path/index.js',
+      '/path/to/node_modules/some-package/lib/babel-plugin-name.js',
+      '/path/to/node_modules/@scope/some-package/lib/babel-plugin-name.js'
+    ];
 
     it('correctly returns -1', () => {
       expect(findPluginIndex([], 'foo-bar')).to.equal(-1);
@@ -20,6 +26,13 @@ describe('Utilities | plugin-configuration', () => {
       expect(findPluginIndex(plugins, 'babel-plugin-short-name')).to.equal(0);
       expect(findPluginIndex(plugins, 'babel-plugin-long-name')).to.equal(1);
       expect(findPluginIndex(plugins, 'babel-plugin-full-path')).to.equal(2);
+    });
+
+    it('locates plugin in non-plugin package when requested by full path', () => {
+      expect(findPluginIndex(plugins, '/path/to/node_modules/some-package/lib/babel-plugin-name.js')).to.equal(3);
+      expect(findPluginIndex(plugins, '/path/to/node_modules/@scope/some-package/lib/babel-plugin-name.js')).to.equal(
+        4
+      );
     });
   });
 });

--- a/tests/-private/plugin-names-test.ts
+++ b/tests/-private/plugin-names-test.ts
@@ -51,22 +51,46 @@ describe('Utilities | plugin-names', () => {
       expect(resolvePluginName(['babel-plugin-bar', {}])).to.equal('babel-plugin-bar');
     });
 
-    it('resolves names from absolute plugin paths', () => {
-      expect(resolvePluginName('/full/path/to/node_modules/resolved-plugin-name/index.js')).to.equal(
-        'resolved-plugin-name'
+    it('resolves babel plugin names from absolute plugin paths', () => {
+      expect(resolvePluginName('/full/path/to/node_modules/babel-plugin-name/index.js')).to.equal('babel-plugin-name');
+
+      expect(resolvePluginName('/full/path/to/node_modules/@babel/plugin-name/index.js')).to.equal(
+        '@babel/plugin-name'
       );
 
-      expect(resolvePluginName('/full/path/to/node_modules/@scope/resolved-plugin-name/index.js')).to.equal(
-        '@scope/resolved-plugin-name'
+      expect(resolvePluginName('/full/path/to/node_modules/@scope/babel-plugin-name/index.js')).to.equal(
+        '@scope/babel-plugin-name'
       );
 
-      expect(resolvePluginName('C:\\full\\path\\to\\node_modules\\resolved-plugin-name\\index.js')).to.equal(
-        'resolved-plugin-name'
+      expect(resolvePluginName('C:\\full\\path\\to\\node_modules\\babel-plugin-name\\index.js')).to.equal(
+        'babel-plugin-name'
       );
 
-      expect(resolvePluginName('C:\\full\\path\\to\\node_modules\\@scope\\resolved-plugin-name\\index.js')).to.equal(
-        '@scope/resolved-plugin-name'
+      expect(resolvePluginName('C:\\full\\path\\to\\node_modules\\@babel\\plugin-name\\index.js')).to.equal(
+        '@babel/plugin-name'
       );
+
+      expect(resolvePluginName('C:\\full\\path\\to\\node_modules\\@scope\\babel-plugin-name\\index.js')).to.equal(
+        '@scope/babel-plugin-name'
+      );
+    });
+
+    it('returns untouched path for non-babel-plugin package', () => {
+      expect(resolvePluginName('/full/path/to/node_modules/package-name/lib/babel-plugin-name.js')).to.equal(
+        '/full/path/to/node_modules/package-name/lib/babel-plugin-name.js'
+      );
+
+      expect(resolvePluginName('/full/path/to/node_modules/@scope/package-name/lib/babel-plugin-name.js')).to.equal(
+        '/full/path/to/node_modules/@scope/package-name/lib/babel-plugin-name.js'
+      );
+
+      expect(resolvePluginName('C:\\full\\path\\to\\node_modules\\package-name\\lib\\babel-plugin-name.js')).to.equal(
+        'C:\\full\\path\\to\\node_modules\\package-name\\lib\\babel-plugin-name.js'
+      );
+
+      expect(
+        resolvePluginName('C:\\full\\path\\to\\node_modules\\@scope\\package-name\\lib\\babel-plugin-name.js')
+      ).to.equal('C:\\full\\path\\to\\node_modules\\@scope\\package-name\\lib\\babel-plugin-name.js');
     });
   });
 });

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -12,8 +12,30 @@ describe('Public Helpers', () => {
     let scopedWindowsPathPlugin: BabelPluginConfig = [
       'C:\\path\\to\\node_modules\\@scope\\babel-plugin-scoped-windows-path\\lib\\plugin.js'
     ];
+    let nonBabelPluginPackagePlugin: BabelPluginConfig = [
+      '/path/to/node_modules/some-package/lib/babel-plugin-name.js'
+    ];
+    let nonBabelPluginPackageWindowsPlugin: BabelPluginConfig = [
+      'C:\\path\\to\\node_modules\\some-package\\lib\\babel-plugin-name.js'
+    ];
+    let scopedNonBabelPluginPackagePlugin: BabelPluginConfig = [
+      '/path/to/node_modules/@scope/some-package/lib/babel-plugin-name.js'
+    ];
+    let scopedNonBabelPluginPackageWindowsPlugin: BabelPluginConfig = [
+      'C:\\path\\to\\node_modules\\@scope\\some-package\\lib\\babel-plugin-name.js'
+    ];
 
-    let config = [shortNamePlugin, normalizedNamePlugin, fullPathPlugin, scopedPathPlugin, scopedWindowsPathPlugin];
+    let config = [
+      shortNamePlugin,
+      normalizedNamePlugin,
+      fullPathPlugin,
+      scopedPathPlugin,
+      scopedWindowsPathPlugin,
+      nonBabelPluginPackagePlugin,
+      nonBabelPluginPackageWindowsPlugin,
+      scopedNonBabelPluginPackagePlugin,
+      scopedNonBabelPluginPackageWindowsPlugin
+    ];
 
     it('locates plugins by short and normalized names', () => {
       expect(hasPlugin(config, 'nonexistent')).to.be.false;
@@ -33,6 +55,17 @@ describe('Public Helpers', () => {
       expect(hasPlugin(config, '@scope/scoped-windows-path')).to.be.true;
       expect(hasPlugin(config, '@scope/babel-plugin-scoped-path')).to.be.true;
     });
+
+    it('locates plugins in non-babel-plugin packages by full path', () => {
+      expect(hasPlugin(config, '/path/to/node_modules/some-package/lib/babel-plugin-name.js')).to.be.true;
+
+      expect(hasPlugin(config, 'C:\\path\\to\\node_modules\\some-package\\lib\\babel-plugin-name.js')).to.be.true;
+
+      expect(hasPlugin(config, '/path/to/node_modules/@scope/some-package/lib/babel-plugin-name.js')).to.be.true;
+
+      expect(hasPlugin(config, 'C:\\path\\to\\node_modules\\@scope\\some-package\\lib\\babel-plugin-name.js')).to.be
+        .true;
+    });
   });
 
   describe('findPlugin', () => {
@@ -43,8 +76,30 @@ describe('Public Helpers', () => {
     let scopedWindowsPathPlugin: BabelPluginConfig = [
       'C:\\path\\to\\node_modules\\@scope\\babel-plugin-scoped-windows-path\\lib\\plugin.js'
     ];
+    let nonBabelPluginPackagePlugin: BabelPluginConfig = [
+      '/path/to/node_modules/some-package/lib/babel-plugin-name.js'
+    ];
+    let nonBabelPluginPackageWindowsPlugin: BabelPluginConfig = [
+      'C:\\path\\to\\node_modules\\some-package\\lib\\babel-plugin-name.js'
+    ];
+    let scopedNonBabelPluginPackagePlugin: BabelPluginConfig = [
+      '/path/to/node_modules/@scope/some-package/lib/babel-plugin-name.js'
+    ];
+    let scopedNonBabelPluginPackageWindowsPlugin: BabelPluginConfig = [
+      'C:\\path\\to\\node_modules\\@scope\\some-package\\lib\\babel-plugin-name.js'
+    ];
 
-    let config = [shortNamePlugin, normalizedNamePlugin, fullPathPlugin, scopedPathPlugin, scopedWindowsPathPlugin];
+    let config = [
+      shortNamePlugin,
+      normalizedNamePlugin,
+      fullPathPlugin,
+      scopedPathPlugin,
+      scopedWindowsPathPlugin,
+      nonBabelPluginPackagePlugin,
+      nonBabelPluginPackageWindowsPlugin,
+      scopedNonBabelPluginPackagePlugin,
+      scopedNonBabelPluginPackageWindowsPlugin
+    ];
 
     it('locates plugins by short and normalized names', () => {
       expect(findPlugin(config, 'nonexistent')).to.be.undefined;
@@ -63,6 +118,24 @@ describe('Public Helpers', () => {
 
       expect(findPlugin(config, '@scope/scoped-windows-path')).to.equal(scopedWindowsPathPlugin);
       expect(findPlugin(config, '@scope/babel-plugin-scoped-windows-path')).to.equal(scopedWindowsPathPlugin);
+    });
+
+    it('locates plugins in non-babel-plugin packages by full path', () => {
+      expect(findPlugin(config, '/path/to/node_modules/some-package/lib/babel-plugin-name.js')).to.equal(
+        nonBabelPluginPackagePlugin
+      );
+
+      expect(findPlugin(config, 'C:\\path\\to\\node_modules\\some-package\\lib\\babel-plugin-name.js')).to.equal(
+        nonBabelPluginPackageWindowsPlugin
+      );
+
+      expect(findPlugin(config, '/path/to/node_modules/@scope/some-package/lib/babel-plugin-name.js')).to.equal(
+        scopedNonBabelPluginPackagePlugin
+      );
+
+      expect(
+        findPlugin(config, 'C:\\path\\to\\node_modules\\@scope\\some-package\\lib\\babel-plugin-name.js')
+      ).to.equal(scopedNonBabelPluginPackageWindowsPlugin);
     });
   });
 


### PR DESCRIPTION
The `hasPlugin` and `findPlugin` helpers don't currently support the use-case where a babel plugin has been added that is part of another package. That is, when the package that the plugin lives in is not itself a babel-plugin (and not named as a babel-plugin) it is currently not possible to locate the plugin. This is because a full path found in the plugin config list is always resolved to the package name. If the package name does not start with `babel-plugin` or `@scope/babel-plugin`, it will never match the provided name because it is normalized to add `babel-plugin`.

As an example:

```js
// /path/to/node_modules/ember-some-addon/index.js

const Plugin = require.resolve('./lib/babel-plugin-foo');

module.exports = {
  included(parent) {

  if (!hasPlugin(parent, Plugin)) {
    addPlugin(parent, Plugin);
  }
}
```
The `hasPlugin` guard will always fail here.

This does not work either:
```js
// /path/to/node_modules/ember-some-addon/index.js

const Plugin = require.resolve('./lib/babel-plugin-foo');

module.exports = {
  included(parent) {

  if (!hasPlugin(parent, 'ember-some-addon')) {
    addPlugin(parent, Plugin);
  }
}
```
because `ember-some-addon` is normalized to `babel-plugin-ember-some-addon` and compared to the resolved package name from the full path (`ember-some-addon`).

To make this work, I've added a guard when resolving a full path to check that the resolved package name is named as a babel plugin. If not, the full path is returned untouched, rather than the package name.