### PR TITLE
Locate plugins with module prefix or by full path

### DIFF
--- a/src/-private/plugin-configuration.ts
+++ b/src/-private/plugin-configuration.ts
@@ -1,5 +1,5 @@
 import { ConfigurationTarget, BabelPluginConfig } from '..';
-import { normalizePluginName, resolvePluginName } from './plugin-names';
+import { resolvePluginName } from './plugin-names';
 
 export function getPluginsArray(target: ConfigurationTarget | BabelPluginConfig[]): BabelPluginConfig[] {
   if (Array.isArray(target)) {
@@ -12,6 +12,6 @@ export function getPluginsArray(target: ConfigurationTarget | BabelPluginConfig[
 }
 
 export function findPluginIndex(plugins: BabelPluginConfig[], plugin: string): number {
-  let pluginName = normalizePluginName(plugin);
+  let pluginName = resolvePluginName(plugin);
   return plugins.findIndex(candidate => resolvePluginName(candidate) === pluginName);
 }

--- a/src/-private/plugin-names.ts
+++ b/src/-private/plugin-names.ts
@@ -85,5 +85,5 @@ function findPackageName(modulePath: string): string {
 }
 
 function isPath(name: string): boolean {
-  return /[\\/]/.test(name);
+  return /[\\/]/.test(name) && !name.startsWith('@') && !name.startsWith('module:');
 }

--- a/tests/-private/plugin-configuration-test.ts
+++ b/tests/-private/plugin-configuration-test.ts
@@ -32,5 +32,9 @@ describe('Utilities | plugin-configuration', () => {
       expect(findPluginIndex(plugins, 'module:foo')).to.equal(3);
       expect(findPluginIndex(plugins, 'module:/path/to/node_modules/babel-plugin-full-path/index.js')).to.equal(4);
     });
+
+    it('locates plugins when requested by full path', () => {
+      expect(findPluginIndex(plugins, '/path/to/node_modules/babel-plugin-full-path/index.js')).to.equal(2);
+    });
   });
 });

--- a/tests/-private/plugin-configuration-test.ts
+++ b/tests/-private/plugin-configuration-test.ts
@@ -4,7 +4,13 @@ import { findPluginIndex } from '../../src/-private/plugin-configuration';
 
 describe('Utilities | plugin-configuration', () => {
   describe('findPluginIndex', () => {
-    let plugins = ['short-name', 'babel-plugin-long-name', '/path/to/node_modules/babel-plugin-full-path/index.js'];
+    let plugins = [
+      'short-name',
+      'babel-plugin-long-name',
+      '/path/to/node_modules/babel-plugin-full-path/index.js',
+      'module:foo',
+      'module:/path/to/node_modules/babel-plugin-full-path/index.js'
+    ];
 
     it('correctly returns -1', () => {
       expect(findPluginIndex([], 'foo-bar')).to.equal(-1);
@@ -20,6 +26,11 @@ describe('Utilities | plugin-configuration', () => {
       expect(findPluginIndex(plugins, 'babel-plugin-short-name')).to.equal(0);
       expect(findPluginIndex(plugins, 'babel-plugin-long-name')).to.equal(1);
       expect(findPluginIndex(plugins, 'babel-plugin-full-path')).to.equal(2);
+    });
+
+    it('locates plugins when requested with `module:` prefix', () => {
+      expect(findPluginIndex(plugins, 'module:foo')).to.equal(3);
+      expect(findPluginIndex(plugins, 'module:/path/to/node_modules/babel-plugin-full-path/index.js')).to.equal(4);
     });
   });
 });

--- a/tests/-private/plugin-names-test.ts
+++ b/tests/-private/plugin-names-test.ts
@@ -68,5 +68,13 @@ describe('Utilities | plugin-names', () => {
         '@scope/resolved-plugin-name'
       );
     });
+
+    it('resolves remainder after `module:` prefix untouched', () => {
+      expect(resolvePluginName('module:foo')).to.equal('foo');
+
+      expect(resolvePluginName('module:/full/path/to/node_modules/resolved-plugin-name/index.js')).to.equal(
+        '/full/path/to/node_modules/resolved-plugin-name/index.js'
+      );
+    });
   });
 });

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -12,8 +12,18 @@ describe('Public Helpers', () => {
     let scopedWindowsPathPlugin: BabelPluginConfig = [
       'C:\\path\\to\\node_modules\\@scope\\babel-plugin-scoped-windows-path\\lib\\plugin.js'
     ];
+    let modulePlugin: BabelPluginConfig = ['module:foo'];
+    let modulePathPlugin: BabelPluginConfig = ['module:/path/to/node_modules/some-package/lib/babel-plugin-name.js'];
 
-    let config = [shortNamePlugin, normalizedNamePlugin, fullPathPlugin, scopedPathPlugin, scopedWindowsPathPlugin];
+    let config = [
+      shortNamePlugin,
+      normalizedNamePlugin,
+      fullPathPlugin,
+      scopedPathPlugin,
+      scopedWindowsPathPlugin,
+      modulePlugin,
+      modulePathPlugin
+    ];
 
     it('locates plugins by short and normalized names', () => {
       expect(hasPlugin(config, 'nonexistent')).to.be.false;
@@ -33,6 +43,12 @@ describe('Public Helpers', () => {
       expect(hasPlugin(config, '@scope/scoped-windows-path')).to.be.true;
       expect(hasPlugin(config, '@scope/babel-plugin-scoped-path')).to.be.true;
     });
+
+    it('locates plugins with `module:` prefix', () => {
+      expect(hasPlugin(config, 'module:foo')).to.be.true;
+
+      expect(hasPlugin(config, 'module:/path/to/node_modules/some-package/lib/babel-plugin-name.js')).to.be.true;
+    });
   });
 
   describe('findPlugin', () => {
@@ -43,8 +59,18 @@ describe('Public Helpers', () => {
     let scopedWindowsPathPlugin: BabelPluginConfig = [
       'C:\\path\\to\\node_modules\\@scope\\babel-plugin-scoped-windows-path\\lib\\plugin.js'
     ];
+    let modulePlugin: BabelPluginConfig = ['module:foo'];
+    let modulePathPlugin: BabelPluginConfig = ['module:/path/to/node_modules/some-package/lib/babel-plugin-name.js'];
 
-    let config = [shortNamePlugin, normalizedNamePlugin, fullPathPlugin, scopedPathPlugin, scopedWindowsPathPlugin];
+    let config = [
+      shortNamePlugin,
+      normalizedNamePlugin,
+      fullPathPlugin,
+      scopedPathPlugin,
+      scopedWindowsPathPlugin,
+      modulePlugin,
+      modulePathPlugin
+    ];
 
     it('locates plugins by short and normalized names', () => {
       expect(findPlugin(config, 'nonexistent')).to.be.undefined;
@@ -63,6 +89,14 @@ describe('Public Helpers', () => {
 
       expect(findPlugin(config, '@scope/scoped-windows-path')).to.equal(scopedWindowsPathPlugin);
       expect(findPlugin(config, '@scope/babel-plugin-scoped-windows-path')).to.equal(scopedWindowsPathPlugin);
+    });
+
+    it('locates plugins with `module:` prefix', () => {
+      expect(findPlugin(config, 'module:foo')).to.equal(modulePlugin);
+
+      expect(findPlugin(config, 'module:/path/to/node_modules/some-package/lib/babel-plugin-name.js')).to.equal(
+        modulePathPlugin
+      );
     });
   });
 

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -49,6 +49,15 @@ describe('Public Helpers', () => {
 
       expect(hasPlugin(config, 'module:/path/to/node_modules/some-package/lib/babel-plugin-name.js')).to.be.true;
     });
+
+    it('locates plugins by full path', () => {
+      expect(hasPlugin(config, '/path/to/node_modules/babel-plugin-full-path/index.js')).to.be.true;
+
+      expect(hasPlugin(config, '/path/to/node_modules/@scope/babel-plugin-scoped-path/lib/plugin.js')).to.be.true;
+
+      expect(hasPlugin(config, 'C:\\path\\to\\node_modules\\@scope\\babel-plugin-scoped-windows-path\\lib\\plugin.js'))
+        .to.be.true;
+    });
   });
 
   describe('findPlugin', () => {
@@ -97,6 +106,18 @@ describe('Public Helpers', () => {
       expect(findPlugin(config, 'module:/path/to/node_modules/some-package/lib/babel-plugin-name.js')).to.equal(
         modulePathPlugin
       );
+    });
+
+    it('locates plugins by full path', () => {
+      expect(findPlugin(config, '/path/to/node_modules/babel-plugin-full-path/index.js')).to.equal(fullPathPlugin);
+
+      expect(findPlugin(config, '/path/to/node_modules/@scope/babel-plugin-scoped-path/lib/plugin.js')).to.equal(
+        scopedPathPlugin
+      );
+
+      expect(
+        findPlugin(config, 'C:\\path\\to\\node_modules\\@scope\\babel-plugin-scoped-windows-path\\lib\\plugin.js')
+      ).to.equal(scopedWindowsPathPlugin);
     });
   });
 


### PR DESCRIPTION
This adds the ability for `hasPlugin` and `findPlugin` to work:
* when plugins have been added with the `module:` prefix
* by providing the full path to a plugin added by full path